### PR TITLE
Fix Terraform public key path

### DIFF
--- a/terraform-code/keypair.tf
+++ b/terraform-code/keypair.tf
@@ -5,5 +5,5 @@
 # Crea el Key Pair en AWS usando tu clave pública
 resource "aws_key_pair" "user1" {
   key_name   = var.key_name # "user1keypair"
-  public_key = file(var.public_key_path)
+  public_key = file("${path.module}/${var.public_key_path}")
 }

--- a/terraform-code/variables.tf
+++ b/terraform-code/variables.tf
@@ -13,13 +13,13 @@ variable "private_subnet_b_cidr" {
 variable "public_key_path" {
   description = "Path al archivo de clave pública RSA que se cargará como Key Pair en AWS"
   type        = string
-  default     = "${path.module}/user1keypair.pub"
+  default     = "user1keypair.pub"
 }
 # Nombre global-único para el bucket
 variable "app_bucket_name" {
   description = "Nombre opcional del bucket S3 que alojará app.zip; si se deja vacío, se generará uno"
   type        = string
-  default     = ""          # ← sin interpolaciones
+  default     = "" # ← sin interpolaciones
 }
 
 # Key (nombre) del objeto ZIP dentro del bucket


### PR DESCRIPTION
## Summary
- fix path for public key variable
- use module path when reading EC2 key pair

## Testing
- `terraform fmt -recursive`
- `terraform init -input=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6880235919d0832d95f6ab9e22bad250