### PR TITLE
Fix terraform plan step credentials

### DIFF
--- a/.github/workflows/01-create-infra.yml
+++ b/.github/workflows/01-create-infra.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Terraform Plan
         working-directory: terraform-code
         run: terraform plan -input=false
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_REGION }}
 
       - name: Terraform Apply
         working-directory: terraform-code


### PR DESCRIPTION
## Summary
- ensure `terraform plan` step has AWS credentials in `01-create-infra.yml`

## Testing
- `yamllint .github/workflows/01-create-infra.yml`

------
https://chatgpt.com/codex/tasks/task_e_6880274ca4cc832d95d60b0cbb4ccd28